### PR TITLE
Do not dispose of HttpClient instance

### DIFF
--- a/Grey-O-Tron.Library/ApiClients/DadJokes.cs
+++ b/Grey-O-Tron.Library/ApiClients/DadJokes.cs
@@ -5,12 +5,15 @@ namespace GreyOTron.Library.ApiClients
 {
     public class DadJokes
     {
+        private static readonly HttpClient Client = new HttpClient();
+        
         public async Task<string> GetJoke()
         {
-            using var cli = new HttpClient();
-            cli.DefaultRequestHeaders.Clear();
-            cli.DefaultRequestHeaders.Add("Accept", "text/plain");
-            var result = await cli.GetStringAsync("https://icanhazdadjoke.com");
+            Client.DefaultRequestHeaders.Clear();
+            Client.DefaultRequestHeaders.Add("Accept", "text/plain");
+            
+            var result = await Client.GetStringAsync("https://icanhazdadjoke.com");
+            
             return result;
         }
     }


### PR DESCRIPTION
As outlined in [this article](https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/), disposal of HttpClient instances is incorrect and can lead to issues such as socket exhaustion under heavy load. This PR simply changes to a static instance of HttpClient to prevent this.